### PR TITLE
Add default URLs for missing portfolio items

### DIFF
--- a/src/data.js
+++ b/src/data.js
@@ -19,6 +19,7 @@ export const reactPortfolio = [
       id: 1,
       title: "Web Social Media App",
       img: "https://cdn.dribbble.com/users/5031392/screenshots/15467520/media/c36b3b15b25b1e190d081abdbbf947cf.png?compress=1&resize=1200x900",
+      url: "#"
     },
   ];
   
@@ -38,7 +39,7 @@ export const reactPortfolio = [
       title: "Comming Soon",
       img:
         "./assets/placeholder.jpeg",
-      
+      url: "#",
     },
   ];
   export const mobilePortfolio = [
@@ -47,5 +48,6 @@ export const reactPortfolio = [
       title: "Comming Soon",
       img:
         "./assets/placeholder.jpeg",
+      url: "#",
     },
   ];


### PR DESCRIPTION
## Summary
- ensure portfolio items always have an href

## Testing
- `yarn test --watchAll=false` *(fails: This package doesn't seem to be present in your lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_686be94c63508325a9307fd1bac04c12